### PR TITLE
feat: Implement homepage with shadcn/ui components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mini-template",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "@upstash/redis": "^1.35.0",
         "clanker-sdk": "^4.0.18",
         "class-variance-authority": "^0.7.1",
@@ -2651,6 +2652,39 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3329,7 +3363,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4960,7 +4994,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "@upstash/redis": "^1.35.0",
     "clanker-sdk": "^4.0.18",
     "class-variance-authority": "^0.7.1",

--- a/src/app/configurator/page.tsx
+++ b/src/app/configurator/page.tsx
@@ -1,0 +1,17 @@
+export default function ConfiguratorPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="container mx-auto">
+        <h1 className="text-4xl font-bold mb-4">Clanker v4 Configurator</h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          Configure and deploy your Clanker v4 instance with ease.
+        </p>
+        <div className="bg-card rounded-lg border p-8">
+          <p className="text-muted-foreground">
+            Configurator functionality coming soon...
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,17 @@
+export default function DocsPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="container mx-auto">
+        <h1 className="text-4xl font-bold mb-4">Documentation</h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          Learn how to use Clanker v4 with our comprehensive guides.
+        </p>
+        <div className="bg-card rounded-lg border p-8">
+          <p className="text-muted-foreground">
+            Documentation coming soon...
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,5 @@
+import HomePage from '@/components/HomePage';
+
 export default function Home() {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-8 bg-background">
-      <main className="mx-auto max-w-4xl text-center">
-        <h1 className="mb-8 text-4xl font-bold text-foreground sm:text-5xl">
-          Welcome to Clanker Tools
-        </h1>
-        <p className="mb-12 text-lg text-muted-foreground">
-          Your comprehensive platform for Clanker token management and creation.
-          Explore powerful tools designed to streamline your token operations.
-        </p>
-        <div className="rounded-lg bg-card p-8">
-          <h2 className="mb-4 text-2xl font-semibold text-card-foreground">
-            Getting Started
-          </h2>
-          <p className="text-muted-foreground">
-            Use the menu to navigate through different tools and features.
-            More features and tools will be added soon!
-          </p>
-        </div>
-      </main>
-    </div>
-  );
+  return <HomePage />;
 }

--- a/src/app/sdk-examples/page.tsx
+++ b/src/app/sdk-examples/page.tsx
@@ -1,0 +1,17 @@
+export default function SDKExamplesPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="container mx-auto">
+        <h1 className="text-4xl font-bold mb-4">SDK Examples</h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          Explore code examples and integrations for the Clanker SDK.
+        </p>
+        <div className="bg-card rounded-lg border p-8">
+          <p className="text-muted-foreground">
+            SDK examples coming soon...
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen py-12">
+      <div data-testid="homepage-container" className="container mx-auto px-4">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold mb-4">Clanker Tools</h1>
+          <p className="text-lg text-muted-foreground">
+            Your gateway to Clanker v4 deployment and management
+          </p>
+        </div>
+
+        <div data-testid="cards-grid" className="grid md:grid-cols-3 gap-6">
+          <div data-testid="feature-card">
+            <Card data-testid="configurator-card" className="flex flex-col h-full">
+              <CardHeader>
+                <CardTitle>Clanker v4 Configurator</CardTitle>
+                <CardDescription>
+                  Easily configure and deploy your Clanker v4 instance with our intuitive interface
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 flex flex-col justify-end">
+                <Button asChild className="w-full">
+                  <Link href="/configurator">Launch Configurator</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div data-testid="feature-card">
+            <Card data-testid="docs-card" className="flex flex-col h-full">
+              <CardHeader>
+                <CardTitle>Documentation</CardTitle>
+                <CardDescription>
+                  Learn how to use Clanker v4 with comprehensive guides and API references
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 flex flex-col justify-end">
+                <Button asChild variant="secondary" className="w-full">
+                  <Link href="/docs">View Docs</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div data-testid="feature-card">
+            <Card data-testid="sdk-card" className="flex flex-col h-full">
+              <CardHeader>
+                <CardTitle>SDK Examples</CardTitle>
+                <CardDescription>
+                  Explore code examples and integrations for the Clanker SDK
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 flex flex-col justify-end">
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/sdk-examples">Browse Examples</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/SidebarMenu.tsx
+++ b/src/components/SidebarMenu.tsx
@@ -37,13 +37,34 @@ export default function SidebarMenu() {
             Menu
           </h2>
         </div>
-        <div className="p-4">
+        <div className="p-4 space-y-2">
           <Link
             href="/"
             className="block rounded-md px-4 py-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             onClick={toggleMenu}
           >
             Home
+          </Link>
+          <Link
+            href="/configurator"
+            className="block rounded-md px-4 py-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            onClick={toggleMenu}
+          >
+            Configurator
+          </Link>
+          <Link
+            href="/docs"
+            className="block rounded-md px-4 py-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            onClick={toggleMenu}
+          >
+            Documentation
+          </Link>
+          <Link
+            href="/sdk-examples"
+            className="block rounded-md px-4 py-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            onClick={toggleMenu}
+          >
+            SDK Examples
           </Link>
         </div>
       </nav>

--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HomePage from '../HomePage';
+
+describe('HomePage', () => {
+  it('renders the main heading', () => {
+    render(<HomePage />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Clanker Tools');
+  });
+
+  it('renders the subtitle', () => {
+    render(<HomePage />);
+    const subtitle = screen.getByText(/Your gateway to Clanker v4 deployment and management/i);
+    expect(subtitle).toBeInTheDocument();
+  });
+
+  it('renders three feature cards', () => {
+    render(<HomePage />);
+    const cards = screen.getAllByTestId('feature-card');
+    expect(cards).toHaveLength(3);
+  });
+
+  it('renders the configurator card with correct content', () => {
+    render(<HomePage />);
+    const configuratorCard = screen.getByTestId('configurator-card');
+    expect(configuratorCard).toBeInTheDocument();
+    
+    const heading = configuratorCard.querySelector('[data-slot="card-title"]');
+    expect(heading).toHaveTextContent('Clanker v4 Configurator');
+    
+    const description = configuratorCard.querySelector('[data-slot="card-description"]');
+    expect(description).toHaveTextContent(/Easily configure and deploy your Clanker v4 instance/i);
+    
+    const button = configuratorCard.querySelector('a');
+    expect(button).toHaveAttribute('href', '/configurator');
+    expect(button).toHaveTextContent('Launch Configurator');
+  });
+
+  it('renders the documentation card with correct content', () => {
+    render(<HomePage />);
+    const docsCard = screen.getByTestId('docs-card');
+    expect(docsCard).toBeInTheDocument();
+    
+    const heading = docsCard.querySelector('[data-slot="card-title"]');
+    expect(heading).toHaveTextContent('Documentation');
+    
+    const description = docsCard.querySelector('[data-slot="card-description"]');
+    expect(description).toHaveTextContent(/Learn how to use Clanker v4/i);
+    
+    const button = docsCard.querySelector('a');
+    expect(button).toHaveAttribute('href', '/docs');
+    expect(button).toHaveTextContent('View Docs');
+  });
+
+  it('renders the SDK examples card with correct content', () => {
+    render(<HomePage />);
+    const sdkCard = screen.getByTestId('sdk-card');
+    expect(sdkCard).toBeInTheDocument();
+    
+    const heading = sdkCard.querySelector('[data-slot="card-title"]');
+    expect(heading).toHaveTextContent('SDK Examples');
+    
+    const description = sdkCard.querySelector('[data-slot="card-description"]');
+    expect(description).toHaveTextContent(/Explore code examples/i);
+    
+    const button = sdkCard.querySelector('a');
+    expect(button).toHaveAttribute('href', '/sdk-examples');
+    expect(button).toHaveTextContent('Browse Examples');
+  });
+
+  it('has proper responsive classes', () => {
+    render(<HomePage />);
+    const container = screen.getByTestId('homepage-container');
+    expect(container).toHaveClass('container', 'mx-auto', 'px-4');
+    
+    const grid = screen.getByTestId('cards-grid');
+    expect(grid).toHaveClass('grid', 'md:grid-cols-3', 'gap-6');
+  });
+
+  it('renders with proper accessibility structure', () => {
+    render(<HomePage />);
+    
+    // Should have a main landmark
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
+    
+    // Should have one h1
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toBeInTheDocument();
+    
+    // Should have three cards with titles
+    const configuratorCard = screen.getByTestId('configurator-card');
+    const docsCard = screen.getByTestId('docs-card');
+    const sdkCard = screen.getByTestId('sdk-card');
+    
+    [configuratorCard, docsCard, sdkCard].forEach(card => {
+      const title = card.querySelector('[data-slot="card-title"]');
+      expect(title).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}


### PR DESCRIPTION
## Summary
- Implemented a modern homepage using shadcn/ui components as specified in issue #4
- Added responsive card layout with three feature sections (Configurator, Documentation, SDK Examples)
- Created placeholder pages for all linked sections
- Updated navigation menu with new page links

## Changes
- ✅ Installed shadcn/ui Button and Card components
- ✅ Created HomePage component with responsive grid layout
- ✅ Added comprehensive tests following TDD approach
- ✅ Created placeholder pages for /configurator, /docs, and /sdk-examples
- ✅ Updated SidebarMenu with navigation links
- ✅ Ensured responsive design works on mobile and desktop
- ✅ All tests passing (30 tests total)
- ✅ No linting errors

## Test Results
```
Test Suites: 5 passed, 5 total
Tests:       30 passed, 30 total
```

## Screenshots
The homepage features:
- Clean, modern design with shadcn/ui components
- Responsive 3-column grid that stacks on mobile
- Feature cards for Configurator, Documentation, and SDK Examples
- Consistent theming with the existing Dracula color scheme

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)