### PR TITLE
feat: Configure Farcaster Mini App Foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mini-template",
       "version": "0.1.0",
       "dependencies": {
+        "@farcaster/frame-sdk": "^0.0.64",
         "@radix-ui/react-slot": "^1.2.3",
         "@upstash/redis": "^1.35.0",
         "clanker-sdk": "^4.0.18",
@@ -566,7 +567,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1132,6 +1132,101 @@
         "@noble/hashes": "1.4.0",
         "@scure/bip32": "1.4.0",
         "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/@farcaster/frame-core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@farcaster/frame-core/-/frame-core-0.2.0.tgz",
+      "integrity": "sha512-HNxg7A4p5W/HqMMs6CKKJXbhHFpLYrlcOGlvc9k9tRiGBSo8JjAZhyjVUfaXqSIvN0ItCGBVmtB0ULzpktMpTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/web3.js": "^1.98.2",
+        "ox": "^0.4.4",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/@farcaster/frame-core/node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@farcaster/frame-sdk": {
+      "version": "0.0.64",
+      "resolved": "https://registry.npmjs.org/@farcaster/frame-sdk/-/frame-sdk-0.0.64.tgz",
+      "integrity": "sha512-mrFXmkRc5RR6/PDaN3Rho4YFEh2oI2s9eg5NA9pHUEN9oPt4Sd5ShdeX/0/uVxOk3/EbVL69lGIGce5hYbUyhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@farcaster/frame-core": "0.2.0",
+        "@farcaster/quick-auth": "^0.0.6",
+        "comlink": "^4.4.2",
+        "eventemitter3": "^5.0.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@farcaster/frame-sdk/node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@farcaster/quick-auth": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@farcaster/quick-auth/-/quick-auth-0.0.6.tgz",
+      "integrity": "sha512-tiZndhpfDtEhaKlkmS5cVDuS+A/tafqZT3y9I44rC69m3beJok6e8dIH2JhxVy3EvOWTyTBnrmNn6GOOh+qK6A==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^5.2.3",
+        "zod": "^3.25.1"
+      },
+      "peerDependencies": {
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2762,6 +2857,151 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.1.1.tgz",
+      "integrity": "sha512-iPQW3UZ2Vi7QFBo2r9tw0NubtH8EdrhhmZulx6lC8V5a+qjaxovtM/q/UW2BTNpqqHLfO0tIcLyBLrNH4HTWPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.1.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.1.1.tgz",
+      "integrity": "sha512-m20IUPJhPUmPkHSlZ2iMAjJ7PaYUvlMtFhCQYzm9BEBSI6OCvXTG3GAPpAnSGRBfg5y+QNqqmKn4QHU3B6zzCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.1.1",
+        "@solana/errors": "2.1.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.1.1.tgz",
+      "integrity": "sha512-sj6DaWNbSJFvLzT8UZoabMefQUfSW/8tXK7NTiagsDmh+Q87eyQDDC9L3z+mNmx9b6dEf6z660MOIplDD2nfEw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.2",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.2.tgz",
+      "integrity": "sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -3219,6 +3459,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3401,6 +3650,21 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4045,6 +4309,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4450,6 +4726,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4479,6 +4764,23 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
+      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4538,6 +4840,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4578,6 +4889,20 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4928,6 +5253,21 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5174,6 +5514,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dequal": {
@@ -5508,6 +5860,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/escalade": {
@@ -6062,6 +6429,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6111,6 +6486,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -6709,6 +7090,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -7351,6 +7741,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isows": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
@@ -7469,6 +7868,74 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.2.0.tgz",
+      "integrity": "sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest": {
@@ -8424,6 +8891,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8524,6 +9000,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -9246,6 +9728,60 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -10160,6 +10696,71 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.1.tgz",
+      "integrity": "sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^8.3.4",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^8.3.2",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -10618,6 +11219,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -10900,6 +11516,15 @@
         }
       }
     },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11029,6 +11654,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -11318,7 +11948,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11433,6 +12062,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@farcaster/frame-sdk": "^0.0.64",
     "@radix-ui/react-slot": "^1.2.3",
     "@upstash/redis": "^1.35.0",
     "clanker-sdk": "^4.0.18",

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="192" height="192" rx="20" fill="#40E0D0"/>
+  <text x="96" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" text-anchor="middle" fill="#282A36">C</text>
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="54" fill="#40E0D0"/>
+  <text x="256" y="296" font-family="Arial, sans-serif" font-size="172" font-weight="bold" text-anchor="middle" fill="#282A36">C</text>
+</svg>

--- a/src/app/.well-known/farcaster.json/__tests__/route.test.ts
+++ b/src/app/.well-known/farcaster.json/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '../route'
+
+interface MockRequest {
+  url: string
+}
+
+describe('GET /.well-known/farcaster.json', () => {
+  it('should return valid manifest JSON', async () => {
+    const mockRequest = {
+      url: 'http://localhost:3000/.well-known/farcaster.json',
+    } as MockRequest
+    const response = await GET(mockRequest)
+    
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/json')
+    
+    const data = await response.json()
+    
+    expect(data).toHaveProperty('version')
+    expect(data).toHaveProperty('name')
+    expect(data).toHaveProperty('short_name')
+    expect(data).toHaveProperty('launch_url')
+    expect(data).toHaveProperty('icons')
+    expect(data).toHaveProperty('start_url')
+    expect(data).toHaveProperty('display')
+    expect(data).toHaveProperty('theme_color')
+    expect(data).toHaveProperty('background_color')
+  })
+
+  it('should have correct manifest structure', async () => {
+    const mockRequest = {
+      url: 'http://localhost:3000/.well-known/farcaster.json',
+    } as MockRequest
+    const response = await GET(mockRequest)
+    const data = await response.json()
+    
+    expect(data.version).toBe('1')
+    expect(data.name).toBe('Clanker Tools')
+    expect(data.short_name).toBe('Clanker')
+    expect(data.launch_url).toBe('/')
+    expect(data.start_url).toBe('/')
+    expect(data.display).toBe('standalone')
+    expect(data.theme_color).toBe('#40E0D0')
+    expect(data.background_color).toBe('#282A36')
+  })
+
+  it('should have valid icon configuration', async () => {
+    const mockRequest = {
+      url: 'http://localhost:3000/.well-known/farcaster.json',
+    } as MockRequest
+    const response = await GET(mockRequest)
+    const data = await response.json()
+    
+    expect(Array.isArray(data.icons)).toBe(true)
+    expect(data.icons.length).toBeGreaterThan(0)
+    
+    data.icons.forEach((icon: { src: string; sizes: string; type: string }) => {
+      expect(icon).toHaveProperty('src')
+      expect(icon).toHaveProperty('sizes')
+      expect(icon).toHaveProperty('type')
+    })
+  })
+
+  it('should have caching headers', async () => {
+    const mockRequest = {
+      url: 'http://localhost:3000/.well-known/farcaster.json',
+    } as MockRequest
+    const response = await GET(mockRequest)
+    
+    expect(response.headers.get('cache-control')).toBeTruthy()
+  })
+})

--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const manifest = {
+    version: '1',
+    name: 'Clanker Tools',
+    short_name: 'Clanker',
+    launch_url: '/',
+    start_url: '/',
+    display: 'standalone',
+    theme_color: '#40E0D0',
+    background_color: '#282A36',
+    icons: [
+      {
+        src: '/icon-192.png',
+        sizes: '192x192',
+        type: 'image/png'
+      },
+      {
+        src: '/icon-512.png',
+        sizes: '512x512',
+        type: 'image/png'
+      }
+    ]
+  }
+
+  return NextResponse.json(manifest, {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600'
+    }
+  })
+}

--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -12,14 +12,14 @@ export async function GET() {
     background_color: '#282A36',
     icons: [
       {
-        src: '/icon-192.png',
+        src: '/icon-192.svg',
         sizes: '192x192',
-        type: 'image/png'
+        type: 'image/svg+xml'
       },
       {
-        src: '/icon-512.png',
+        src: '/icon-512.svg',
         sizes: '512x512',
-        type: 'image/png'
+        type: 'image/svg+xml'
       }
     ]
   }

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import RootLayout from '../layout'
+import { metadata, viewport } from '../layout'
+
+jest.mock('@/components/Header', () => ({
+  __esModule: true,
+  default: () => <div data-testid="header">Header</div>
+}))
+
+jest.mock('@/components/SidebarMenu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="sidebar">Sidebar</div>
+}))
+
+jest.mock('@/components/providers/FarcasterProvider', () => ({
+  FarcasterProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+describe('RootLayout', () => {
+  it('should render with FarcasterProvider', () => {
+    const { getByText } = render(
+      <RootLayout>
+        <div>Test Content</div>
+      </RootLayout>
+    )
+    
+    expect(getByText('Test Content')).toBeInTheDocument()
+  })
+
+  it('should render with proper structure', () => {
+    const { getByTestId } = render(
+      <RootLayout>
+        <div>Test Content</div>
+      </RootLayout>
+    )
+    
+    expect(getByTestId('header')).toBeInTheDocument()
+    expect(getByTestId('sidebar')).toBeInTheDocument()
+  })
+})
+
+describe('Viewport Configuration', () => {
+  it('should have correct viewport settings', () => {
+    expect(viewport).toBeDefined()
+    expect(viewport.width).toBe(424)
+    expect(viewport.height).toBe(695)
+    expect(viewport.initialScale).toBe(1)
+    expect(viewport.maximumScale).toBe(1)
+    expect(viewport.userScalable).toBe(false)
+    expect(viewport.viewportFit).toBe('cover')
+  })
+})
+
+describe('Metadata', () => {
+  it('should have updated metadata for Farcaster', () => {
+    expect(metadata.title).toBe('Clanker Tools')
+    expect(metadata.description).toBe('Your comprehensive platform for Clanker token management')
+    expect(metadata.viewport).toBeUndefined()
+  })
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,3 +124,11 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Safe area support for mobile devices */
+.safe-area-inset {
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Header from "@/components/Header";
 import SidebarMenu from "@/components/SidebarMenu";
+import { FarcasterProvider } from "@/components/providers/FarcasterProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -19,6 +20,15 @@ export const metadata: Metadata = {
   description: "Your comprehensive platform for Clanker token management",
 };
 
+export const viewport: Viewport = {
+  width: 424,
+  height: 695,
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -27,13 +37,15 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground safe-area-inset`}
       >
-        <SidebarMenu />
-        <div className="flex min-h-screen flex-col">
-          <Header />
-          <main className="flex-1">{children}</main>
-        </div>
+        <FarcasterProvider>
+          <SidebarMenu />
+          <div className="flex min-h-screen flex-col">
+            <Header />
+            <main className="flex-1">{children}</main>
+          </div>
+        </FarcasterProvider>
       </body>
     </html>
   );

--- a/src/components/providers/FarcasterProvider.tsx
+++ b/src/components/providers/FarcasterProvider.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import sdk from '@farcaster/frame-sdk'
+
+interface FarcasterProviderProps {
+  children: React.ReactNode
+}
+
+export function FarcasterProvider({ children }: FarcasterProviderProps) {
+  useEffect(() => {
+    const initializeSDK = async () => {
+      try {
+        await sdk.ready()
+      } catch (error) {
+        console.error('Failed to initialize Farcaster SDK:', error)
+      }
+    }
+    
+    initializeSDK()
+  }, [])
+
+  return <>{children}</>
+}

--- a/src/components/providers/FarcasterProvider.tsx
+++ b/src/components/providers/FarcasterProvider.tsx
@@ -10,10 +10,12 @@ interface FarcasterProviderProps {
 export function FarcasterProvider({ children }: FarcasterProviderProps) {
   useEffect(() => {
     const initializeSDK = async () => {
-      try {
-        await sdk.actions.ready()
-      } catch (error) {
-        console.error('Failed to initialize Farcaster SDK:', error)
+      if (typeof window !== 'undefined') {
+        try {
+          await sdk.actions.ready()
+        } catch (error) {
+          console.error('Failed to initialize Farcaster SDK:', error)
+        }
       }
     }
     

--- a/src/components/providers/FarcasterProvider.tsx
+++ b/src/components/providers/FarcasterProvider.tsx
@@ -11,7 +11,7 @@ export function FarcasterProvider({ children }: FarcasterProviderProps) {
   useEffect(() => {
     const initializeSDK = async () => {
       try {
-        await sdk.ready()
+        await sdk.actions.ready()
       } catch (error) {
         console.error('Failed to initialize Farcaster SDK:', error)
       }

--- a/src/components/providers/__tests__/FarcasterProvider.test.tsx
+++ b/src/components/providers/__tests__/FarcasterProvider.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { FarcasterProvider } from '../FarcasterProvider'
+import sdk from '@farcaster/frame-sdk'
+
+jest.mock('@farcaster/frame-sdk', () => ({
+  __esModule: true,
+  default: {
+    ready: jest.fn(),
+  },
+}))
+
+describe('FarcasterProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render children', () => {
+    const { getByText } = render(
+      <FarcasterProvider>
+        <div>Test Content</div>
+      </FarcasterProvider>
+    )
+    
+    expect(getByText('Test Content')).toBeInTheDocument()
+  })
+
+  it('should call sdk.ready() on mount', async () => {
+    render(
+      <FarcasterProvider>
+        <div>Test Content</div>
+      </FarcasterProvider>
+    )
+    
+    await waitFor(() => {
+      expect(sdk.ready).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should only call sdk.ready() once with multiple children', async () => {
+    render(
+      <FarcasterProvider>
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+      </FarcasterProvider>
+    )
+    
+    await waitFor(() => {
+      expect(sdk.ready).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should not crash when sdk.ready() throws', async () => {
+    const mockError = new Error('SDK initialization failed')
+    ;(sdk.ready as jest.Mock).mockRejectedValueOnce(mockError)
+    
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    
+    const { getByText } = render(
+      <FarcasterProvider>
+        <div>Test Content</div>
+      </FarcasterProvider>
+    )
+    
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize Farcaster SDK:', mockError)
+    })
+    
+    expect(getByText('Test Content')).toBeInTheDocument()
+    
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/components/providers/__tests__/FarcasterProvider.test.tsx
+++ b/src/components/providers/__tests__/FarcasterProvider.test.tsx
@@ -6,7 +6,9 @@ import sdk from '@farcaster/frame-sdk'
 jest.mock('@farcaster/frame-sdk', () => ({
   __esModule: true,
   default: {
-    ready: jest.fn(),
+    actions: {
+      ready: jest.fn(),
+    },
   },
 }))
 
@@ -33,7 +35,7 @@ describe('FarcasterProvider', () => {
     )
     
     await waitFor(() => {
-      expect(sdk.ready).toHaveBeenCalledTimes(1)
+      expect(sdk.actions.ready).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -47,13 +49,13 @@ describe('FarcasterProvider', () => {
     )
     
     await waitFor(() => {
-      expect(sdk.ready).toHaveBeenCalledTimes(1)
+      expect(sdk.actions.ready).toHaveBeenCalledTimes(1)
     })
   })
 
   it('should not crash when sdk.ready() throws', async () => {
     const mockError = new Error('SDK initialization failed')
-    ;(sdk.ready as jest.Mock).mockRejectedValueOnce(mockError)
+    ;(sdk.actions.ready as jest.Mock).mockRejectedValueOnce(mockError)
     
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
     


### PR DESCRIPTION
## Summary
- Configured @farcaster/frame-sdk integration to enable Farcaster mini app functionality
- Created manifest endpoint and viewport configuration for proper mobile display
- Added comprehensive test coverage following TDD principles

## Changes
- **SDK Integration**: Installed and integrated @farcaster/frame-sdk package with FarcasterProvider component
- **Manifest Configuration**: Created /.well-known/farcaster.json endpoint with app metadata and icons
- **Mobile Optimization**: Set viewport to 424x695px and added CSS support for safe area insets
- **Splash Screen**: SDK initialization automatically hides Farcaster splash screen on app load
- **Test Coverage**: Comprehensive tests for SDK initialization, manifest endpoint, and viewport configuration

## Test plan
- [x] All unit tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [ ] Vercel deployment builds successfully
- [ ] App loads correctly in Farcaster client
- [ ] Manifest endpoint is accessible at /.well-known/farcaster.json
- [ ] Viewport displays properly on mobile devices
- [ ] Safe area insets work on devices with notches

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)