### PR TITLE
feat: Configure ENV Variable for Network Selection Between Base Mainnet and Testnet

### DIFF
--- a/docs/NETWORK_CONFIGURATION.md
+++ b/docs/NETWORK_CONFIGURATION.md
@@ -1,0 +1,96 @@
+# Network Configuration Guide
+
+## Overview
+
+This project supports deployment to both Base mainnet and Base Sepolia testnet. Network selection is controlled via the `BASE_NETWORK` environment variable.
+
+## Configuration
+
+### Environment Variable
+
+Set the `BASE_NETWORK` environment variable in your `.env.local` file:
+
+```bash
+# For testnet (default)
+BASE_NETWORK=testnet
+
+# For mainnet
+BASE_NETWORK=mainnet
+```
+
+### Default Behavior
+
+- If `BASE_NETWORK` is not set, the application defaults to **testnet** (Base Sepolia)
+- The value is case-insensitive (`mainnet`, `MAINNET`, `Mainnet` all work)
+- Whitespace is automatically trimmed
+
+### Network Details
+
+#### Base Sepolia (Testnet)
+- Chain ID: `84532` (hex: `0x14A34`)
+- RPC URL: `https://sepolia.base.org`
+- Network Name: Base Sepolia
+- Default network when `BASE_NETWORK` is not set
+
+#### Base Mainnet
+- Chain ID: `8453` (hex: `0x2105`)
+- RPC URL: `https://mainnet.base.org`
+- Network Name: Base
+- Use only for production deployments
+
+## Mainnet Deployment Checklist
+
+Before switching to mainnet:
+
+1. **Test thoroughly on testnet** - Ensure all functionality works as expected
+2. **Review security** - Double-check private key handling and access controls
+3. **Check wallet funding** - Ensure deployer wallet has sufficient ETH for gas
+4. **Update environment variables**:
+   ```bash
+   BASE_NETWORK=mainnet
+   DEPLOYER_PRIVATE_KEY=your_mainnet_private_key
+   ```
+5. **Verify contract addresses** - Ensure all contract addresses (WETH, etc.) are correct for mainnet
+6. **Monitor initial deployments** - Watch the first few token deployments carefully
+
+## API Response
+
+The deployment API now includes network information in the response:
+
+```json
+{
+  "success": true,
+  "tokenAddress": "0x...",
+  "txHash": "0x...",
+  "imageUrl": "ipfs://...",
+  "network": "Base Sepolia",  // or "Base" for mainnet
+  "chainId": 84532            // or 8453 for mainnet
+}
+```
+
+## Troubleshooting
+
+### Invalid Network Error
+If you see "Invalid BASE_NETWORK value", ensure the value is either `mainnet` or `testnet`.
+
+### Wallet Connection Issues
+Users must connect wallets to the correct network:
+- The app accepts connections from both Base mainnet and Base Sepolia
+- Users will see an error if connected to other networks
+
+### RPC Errors
+If you experience RPC errors, the default RPC endpoints may be rate-limited. Consider using your own RPC provider by modifying the network configuration.
+
+## Development Tips
+
+1. Always start development on testnet
+2. Use separate `.env.local` files for different environments
+3. Never commit mainnet private keys to version control
+4. Consider using different deployer wallets for testnet and mainnet
+
+## Security Considerations
+
+- The `DEPLOYER_PRIVATE_KEY` should be kept secure and never exposed
+- Use environment-specific keys (different keys for testnet/mainnet)
+- Monitor deployer wallet balances and transactions
+- Consider using a hardware wallet or secure key management service for mainnet

--- a/src/__mocks__/@farcaster/frame-sdk.ts
+++ b/src/__mocks__/@farcaster/frame-sdk.ts
@@ -10,6 +10,7 @@ const mockSdk = {
   actions: {
     ready: jest.fn().mockResolvedValue(undefined),
     signIn: jest.fn() as jest.MockedFunction<() => Promise<void>>,
+    openUrl: jest.fn().mockResolvedValue(undefined),
   },
   quickAuth: {
     token: null,

--- a/src/app/api/deploy/simple/__tests__/network-config.test.ts
+++ b/src/app/api/deploy/simple/__tests__/network-config.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+import { getNetworkConfig } from '@/lib/network-config';
+
+describe('Deploy Route Network Configuration Integration', () => {
+  const originalEnv = process.env;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Network Selection', () => {
+    it('should use testnet configuration when BASE_NETWORK is not set', () => {
+      delete process.env.BASE_NETWORK;
+      const config = getNetworkConfig();
+      
+      expect(config.chainId).toBe(84532);
+      expect(config.name).toBe('Base Sepolia');
+      expect(config.isMainnet).toBe(false);
+    });
+
+    it('should use mainnet configuration when BASE_NETWORK is set to mainnet', () => {
+      process.env.BASE_NETWORK = 'mainnet';
+      const config = getNetworkConfig();
+      
+      expect(config.chainId).toBe(8453);
+      expect(config.name).toBe('Base');
+      expect(config.isMainnet).toBe(true);
+    });
+
+    it('should handle invalid network configuration', () => {
+      process.env.BASE_NETWORK = 'invalid';
+      
+      expect(() => getNetworkConfig()).toThrow('Invalid BASE_NETWORK value');
+    });
+  });
+});

--- a/src/app/api/deploy/simple/__tests__/route.test.ts
+++ b/src/app/api/deploy/simple/__tests__/route.test.ts
@@ -124,6 +124,8 @@ describe('POST /api/deploy/simple', () => {
       tokenAddress: mockTokenAddress,
       txHash: mockTxHash,
       imageUrl: mockImageUrl,
+      network: 'Base Sepolia',
+      chainId: 84532,
     });
 
     // Check CORS headers

--- a/src/app/token/[address]/__tests__/page.test.tsx
+++ b/src/app/token/[address]/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { useParams, useRouter } from 'next/navigation';
 import { useFarcasterAuth } from '@/components/providers/FarcasterAuthProvider';
 import TokenSuccessPage from '../page';
@@ -78,11 +78,21 @@ describe('TokenSuccessPage', () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    
     (useParams as jest.Mock).mockReturnValue({ address: '0x1234567890abcdef' });
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
     (useFarcasterAuth as jest.Mock).mockReturnValue({ isAuthenticated: true });
     
-    jest.clearAllMocks();
+    // Reset SDK mock
+    const sdk = jest.requireMock('@farcaster/frame-sdk').default;
+    sdk.actions.openUrl.mockClear();
+    
+    // Mock window.location.origin using delete and reassign
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = { origin: 'http://localhost:3000' };
   });
 
   it('renders loading state initially', () => {
@@ -141,7 +151,11 @@ describe('TokenSuccessPage', () => {
     });
 
     const shareButton = screen.getByRole('button', { name: /share on farcaster/i });
-    fireEvent.click(shareButton);
+    
+    // Wait for the button click to trigger the share action
+    await act(async () => {
+      fireEvent.click(shareButton);
+    });
 
     const sdk = jest.requireMock('@farcaster/frame-sdk').default;
     expect(sdk.actions.openUrl).toHaveBeenCalledWith(

--- a/src/hooks/useWalletBalance.ts
+++ b/src/hooks/useWalletBalance.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { BASE_NETWORKS } from '@/lib/network-config';
 
 interface BalanceResult {
   balance: string | null;
@@ -7,8 +8,8 @@ interface BalanceResult {
 }
 
 const RPC_URLS: Record<number, string> = {
-  8453: 'https://mainnet.base.org', // Base mainnet
-  84532: 'https://sepolia.base.org', // Base Sepolia
+  [BASE_NETWORKS.mainnet.chainId]: BASE_NETWORKS.mainnet.rpcUrl,
+  [BASE_NETWORKS.testnet.chainId]: BASE_NETWORKS.testnet.rpcUrl,
 };
 
 export function useWalletBalance(address: string | null, chainId: number | null): BalanceResult {

--- a/src/lib/__tests__/network-config.test.ts
+++ b/src/lib/__tests__/network-config.test.ts
@@ -1,0 +1,119 @@
+import { getNetworkConfig, BASE_NETWORKS } from '@/lib/network-config';
+
+describe('NetworkConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset environment
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getNetworkConfig', () => {
+    it('should return testnet config by default when BASE_NETWORK is not set', () => {
+      delete process.env.BASE_NETWORK;
+      const config = getNetworkConfig();
+      
+      expect(config.chainId).toBe(84532);
+      expect(config.chainIdHex).toBe('0x14A34');
+      expect(config.name).toBe('Base Sepolia');
+      expect(config.rpcUrl).toBe('https://sepolia.base.org');
+      expect(config.isMainnet).toBe(false);
+      expect(config.network).toBe('testnet');
+    });
+
+    it('should return testnet config when BASE_NETWORK is explicitly set to testnet', () => {
+      process.env.BASE_NETWORK = 'testnet';
+      const config = getNetworkConfig();
+      
+      expect(config.chainId).toBe(84532);
+      expect(config.chainIdHex).toBe('0x14A34');
+      expect(config.name).toBe('Base Sepolia');
+      expect(config.rpcUrl).toBe('https://sepolia.base.org');
+      expect(config.isMainnet).toBe(false);
+      expect(config.network).toBe('testnet');
+    });
+
+    it('should return mainnet config when BASE_NETWORK is set to mainnet', () => {
+      process.env.BASE_NETWORK = 'mainnet';
+      const config = getNetworkConfig();
+      
+      expect(config.chainId).toBe(8453);
+      expect(config.chainIdHex).toBe('0x2105');
+      expect(config.name).toBe('Base');
+      expect(config.rpcUrl).toBe('https://mainnet.base.org');
+      expect(config.isMainnet).toBe(true);
+      expect(config.network).toBe('mainnet');
+    });
+
+    it('should handle case-insensitive network names', () => {
+      process.env.BASE_NETWORK = 'MAINNET';
+      let config = getNetworkConfig();
+      expect(config.network).toBe('mainnet');
+
+      process.env.BASE_NETWORK = 'TeStNeT';
+      config = getNetworkConfig();
+      expect(config.network).toBe('testnet');
+    });
+
+    it('should throw error for invalid network names', () => {
+      process.env.BASE_NETWORK = 'invalid-network';
+      expect(() => getNetworkConfig()).toThrow('Invalid BASE_NETWORK value: invalid-network. Must be either "mainnet" or "testnet"');
+    });
+
+    it('should handle whitespace in network names', () => {
+      process.env.BASE_NETWORK = '  mainnet  ';
+      const config = getNetworkConfig();
+      expect(config.network).toBe('mainnet');
+    });
+  });
+
+  describe('BASE_NETWORKS constant', () => {
+    it('should contain mainnet configuration', () => {
+      expect(BASE_NETWORKS.mainnet).toEqual({
+        chainId: 8453,
+        chainIdHex: '0x2105',
+        name: 'Base',
+        rpcUrl: 'https://mainnet.base.org',
+        isMainnet: true,
+        network: 'mainnet'
+      });
+    });
+
+    it('should contain testnet configuration', () => {
+      expect(BASE_NETWORKS.testnet).toEqual({
+        chainId: 84532,
+        chainIdHex: '0x14A34',
+        name: 'Base Sepolia',
+        rpcUrl: 'https://sepolia.base.org',
+        isMainnet: false,
+        network: 'testnet'
+      });
+    });
+  });
+
+  describe('NetworkConfig type', () => {
+    it('should match expected structure', () => {
+      const config = getNetworkConfig();
+      
+      // Type checking happens at compile time, but we can verify structure
+      expect(config).toHaveProperty('chainId');
+      expect(config).toHaveProperty('chainIdHex');
+      expect(config).toHaveProperty('name');
+      expect(config).toHaveProperty('rpcUrl');
+      expect(config).toHaveProperty('isMainnet');
+      expect(config).toHaveProperty('network');
+      
+      expect(typeof config.chainId).toBe('number');
+      expect(typeof config.chainIdHex).toBe('string');
+      expect(typeof config.name).toBe('string');
+      expect(typeof config.rpcUrl).toBe('string');
+      expect(typeof config.isMainnet).toBe('boolean');
+      expect(typeof config.network).toBe('string');
+    });
+  });
+});

--- a/src/lib/network-config.ts
+++ b/src/lib/network-config.ts
@@ -1,0 +1,37 @@
+export interface NetworkConfig {
+  chainId: number;
+  chainIdHex: string;
+  name: string;
+  rpcUrl: string;
+  isMainnet: boolean;
+  network: 'mainnet' | 'testnet';
+}
+
+export const BASE_NETWORKS: Record<string, NetworkConfig> = {
+  mainnet: {
+    chainId: 8453,
+    chainIdHex: '0x2105',
+    name: 'Base',
+    rpcUrl: 'https://mainnet.base.org',
+    isMainnet: true,
+    network: 'mainnet'
+  },
+  testnet: {
+    chainId: 84532,
+    chainIdHex: '0x14A34',
+    name: 'Base Sepolia',
+    rpcUrl: 'https://sepolia.base.org',
+    isMainnet: false,
+    network: 'testnet'
+  }
+};
+
+export function getNetworkConfig(): NetworkConfig {
+  const networkEnv = process.env.BASE_NETWORK?.trim().toLowerCase() || 'testnet';
+  
+  if (networkEnv !== 'mainnet' && networkEnv !== 'testnet') {
+    throw new Error(`Invalid BASE_NETWORK value: ${process.env.BASE_NETWORK}. Must be either "mainnet" or "testnet"`);
+  }
+  
+  return BASE_NETWORKS[networkEnv];
+}

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import sdk from '@farcaster/frame-sdk';
+import { BASE_NETWORKS } from '@/lib/network-config';
 
 interface WalletState {
   isConnected: boolean;
@@ -20,8 +21,8 @@ interface WalletContextType extends WalletState {
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'wallet-state';
-const BASE_CHAIN_ID = 8453;
-const BASE_SEPOLIA_CHAIN_ID = 84532;
+const BASE_CHAIN_ID = BASE_NETWORKS.mainnet.chainId;
+const BASE_SEPOLIA_CHAIN_ID = BASE_NETWORKS.testnet.chainId;
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [walletState, setWalletState] = useState<WalletState>(() => {


### PR DESCRIPTION
## Summary
- Implements environment variable `BASE_NETWORK` to control network selection between Base mainnet and testnet
- Defaults to testnet for safety
- Provides documentation and comprehensive test coverage

## Changes
- ✅ Created `network-config` module with `BASE_NETWORK` support
- ✅ Updated deployment route to use configured network
- ✅ Updated WalletProvider and useWalletBalance to use network constants  
- ✅ Added network info to API response (network name and chainId)
- ✅ Added comprehensive tests for network configuration
- ✅ Updated .env.example with BASE_NETWORK documentation
- ✅ Created network switching documentation

## Test plan
- [x] Run test suite: `npm test`
- [x] Run linting: `npm run lint`
- [x] Test with BASE_NETWORK=testnet (default)
- [x] Test with BASE_NETWORK=mainnet
- [x] Test invalid network values
- [x] Verify deployment API includes network info

Fixes #70

🤖 Generated with [Claude Code](https://claude.ai/code)