### PR TITLE
fix: Update IPFS upload to use Pinata v3 API

### DIFF
--- a/src/app/api/deploy/simple/route.ts
+++ b/src/app/api/deploy/simple/route.ts
@@ -285,11 +285,20 @@ export async function POST(request: NextRequest) {
             details: error.message,
             userMessage: 'The image upload service is temporarily down. Please try again in a few moments.'
           };
+        } else if (error.message.includes('Invalid response from IPFS')) {
+          errorMessage = 'Image upload service returned an unexpected response';
+          errorDetails = {
+            type: 'IPFS_RESPONSE_ERROR',
+            details: error.message,
+            userMessage: 'The image upload service returned an invalid response. This may be due to expired credentials or API changes.',
+            technical: error.message
+          };
         } else {
           errorDetails = {
             type: 'UNKNOWN_ERROR',
             details: error.message,
-            userMessage: 'An unexpected error occurred during image upload'
+            userMessage: 'An unexpected error occurred during image upload',
+            technical: error.message
           };
         }
       }

--- a/src/lib/__tests__/ipfs.test.ts
+++ b/src/lib/__tests__/ipfs.test.ts
@@ -14,11 +14,17 @@ describe('uploadToIPFS', () => {
   });
 
   it('should upload image to IPFS successfully', async () => {
-    const mockHash = 'QmTest123456789';
+    const mockCid = 'bafybeihgxdzljxb26q6nf3r3eifqeedsvt2eubqtskghpme66cgjyw4fra';
     const mockResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        Hash: mockHash,
+        id: '349f1bb2-5d59-4cab-9966-e94c028a05b7',
+        name: 'clanker-token-123456789',
+        cid: mockCid,
+        size: 10,
+        number_of_files: 1,
+        mime_type: 'image/png',
+        group_id: null
       }),
     };
     (fetch as jest.Mock).mockResolvedValue(mockResponse);
@@ -26,9 +32,9 @@ describe('uploadToIPFS', () => {
     const imageBlob = new Blob(['image data'], { type: 'image/png' });
     const result = await uploadToIPFS(imageBlob);
 
-    expect(result).toBe(`ipfs://${mockHash}`);
+    expect(result).toBe(`ipfs://${mockCid}`);
     expect(fetch).toHaveBeenCalledWith(
-      'https://api.pinata.cloud/pinning/pinFileToIPFS',
+      'https://uploads.pinata.cloud/v3/files',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
@@ -71,11 +77,16 @@ describe('uploadToIPFS', () => {
   });
 
   it('should add metadata to the upload', async () => {
-    const mockHash = 'QmTest123456789';
+    const mockCid = 'bafybeihgxdzljxb26q6nf3r3eifqeedsvt2eubqtskghpme66cgjyw4fra';
     const mockResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        Hash: mockHash,
+        id: '349f1bb2',
+        cid: mockCid,
+        size: 10,
+        number_of_files: 1,
+        mime_type: 'image/png',
+        group_id: null
       }),
     };
     (fetch as jest.Mock).mockResolvedValue(mockResponse);
@@ -97,7 +108,7 @@ describe('uploadToIPFS', () => {
     const mockResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        // Missing Hash field
+        // Missing cid field
         success: true,
       }),
     };

--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -51,13 +51,13 @@ export async function uploadToIPFS(imageBlob: Blob): Promise<string> {
   });
   formData.append('pinataMetadata', metadata);
 
-  // Pin to IPFS using Pinata with JWT authentication
-  console.log('[IPFS] Uploading file to Pinata...', {
+  // Pin to IPFS using Pinata v3 API with JWT authentication
+  console.log('[IPFS] Uploading file to Pinata v3...', {
     fileSize: imageBlob.size,
     fileType: imageBlob.type,
   });
   
-  const response = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+  const response = await fetch('https://uploads.pinata.cloud/v3/files', {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${pinataJWT}`,
@@ -76,11 +76,12 @@ export async function uploadToIPFS(imageBlob: Blob): Promise<string> {
   }
 
   const data = await response.json();
-  console.log('[IPFS] Upload successful:', { hash: data.Hash });
+  console.log('[IPFS] Upload response:', data);
   
-  if (!data.Hash) {
-    throw new Error('Invalid response from IPFS');
+  if (!data.cid) {
+    console.error('[IPFS] Invalid response structure:', data);
+    throw new Error(`Invalid response from IPFS: ${JSON.stringify(data)}`);
   }
 
-  return `ipfs://${data.Hash}`;
+  return `ipfs://${data.cid}`;
 }


### PR DESCRIPTION
## Summary
- Migrated IPFS uploads from deprecated Pinata API to v3 endpoint
- Fixed "Invalid response from IPFS" error in Simple Flow
- Updated tests to match new API response format

## Problem
Users were experiencing deployment failures with the error "Invalid response from IPFS" when uploading images in the Simple Flow. Investigation revealed we were using the deprecated Pinata API endpoint that returns different field names than expected.

## Solution
- Updated endpoint from `https://api.pinata.cloud/pinning/pinFileToIPFS` to `https://uploads.pinata.cloud/v3/files`
- Changed response handling to expect `cid` field instead of `Hash` or `IpfsHash`
- Improved error logging to include actual API response for better debugging
- Updated all tests to use the new v3 response format

## Test plan
- [x] All existing tests pass
- [x] Linting passes with no errors
- [ ] Manual test: Upload image in Simple Flow
- [ ] Manual test: Verify image displays correctly after upload
- [ ] Manual test: Deploy token with uploaded image

🤖 Generated with [Claude Code](https://claude.ai/code)