### PR TITLE
fix: Handle Pinata v3 API response data wrapper

### DIFF
--- a/src/app/api/deploy/simple/route.ts
+++ b/src/app/api/deploy/simple/route.ts
@@ -289,16 +289,14 @@ export async function POST(request: NextRequest) {
           errorMessage = 'Image upload service returned an unexpected response';
           errorDetails = {
             type: 'IPFS_RESPONSE_ERROR',
-            details: error.message,
-            userMessage: 'The image upload service returned an invalid response. This may be due to expired credentials or API changes.',
-            technical: error.message
+            details: 'Invalid response structure from IPFS service',
+            userMessage: 'The image upload service returned an invalid response. This may be due to expired credentials or API changes.'
           };
         } else {
           errorDetails = {
             type: 'UNKNOWN_ERROR',
-            details: error.message,
-            userMessage: 'An unexpected error occurred during image upload',
-            technical: error.message
+            details: 'Image upload failed',
+            userMessage: 'An unexpected error occurred during image upload'
           };
         }
       }

--- a/src/lib/__tests__/ipfs.test.ts
+++ b/src/lib/__tests__/ipfs.test.ts
@@ -18,13 +18,15 @@ describe('uploadToIPFS', () => {
     const mockResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        id: '349f1bb2-5d59-4cab-9966-e94c028a05b7',
-        name: 'clanker-token-123456789',
-        cid: mockCid,
-        size: 10,
-        number_of_files: 1,
-        mime_type: 'image/png',
-        group_id: null
+        data: {
+          id: '349f1bb2-5d59-4cab-9966-e94c028a05b7',
+          name: 'clanker-token-123456789',
+          cid: mockCid,
+          size: 10,
+          number_of_files: 1,
+          mime_type: 'image/png',
+          group_id: null
+        }
       }),
     };
     (fetch as jest.Mock).mockResolvedValue(mockResponse);
@@ -81,12 +83,14 @@ describe('uploadToIPFS', () => {
     const mockResponse = {
       ok: true,
       json: jest.fn().mockResolvedValue({
-        id: '349f1bb2',
-        cid: mockCid,
-        size: 10,
-        number_of_files: 1,
-        mime_type: 'image/png',
-        group_id: null
+        data: {
+          id: '349f1bb2',
+          cid: mockCid,
+          size: 10,
+          number_of_files: 1,
+          mime_type: 'image/png',
+          group_id: null
+        }
       }),
     };
     (fetch as jest.Mock).mockResolvedValue(mockResponse);

--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -75,12 +75,15 @@ export async function uploadToIPFS(imageBlob: Blob): Promise<string> {
     throw new Error(`IPFS upload failed: ${response.status} ${response.statusText}`);
   }
 
-  const data = await response.json();
-  console.log('[IPFS] Upload response:', data);
+  const responseData = await response.json();
+  console.log('[IPFS] Upload response:', responseData);
+  
+  // Handle both direct response and data-wrapped response
+  const data = responseData.data || responseData;
   
   if (!data.cid) {
-    console.error('[IPFS] Invalid response structure:', data);
-    throw new Error(`Invalid response from IPFS: ${JSON.stringify(data)}`);
+    console.error('[IPFS] Invalid response structure:', responseData);
+    throw new Error(`Invalid response from IPFS: ${JSON.stringify(responseData)}`);
   }
 
   return `ipfs://${data.cid}`;


### PR DESCRIPTION
## Summary
- Fixed IPFS upload error caused by Pinata v3 API response format
- Updated response handling to support data-wrapped responses
- Improved error messages without exposing sensitive data

## Problem
Users were experiencing "Invalid response from IPFS" errors when uploading images in the Simple Flow. The error showed that Pinata v3 API returns responses wrapped in a `data` object:

```json
{
  "data": {
    "id": "...",
    "cid": "...",
    // other fields
  }
}
```

But our code was expecting the fields directly in the response.

## Solution
- Updated `uploadToIPFS` to handle both direct responses and data-wrapped responses
- Changed response parsing to: `const data = responseData.data || responseData`
- Updated all tests to use the correct response format
- Removed `technical` field from error responses to avoid exposing sensitive data

## Test Plan
- [x] All existing tests pass (556 tests)
- [x] Linting passes with no errors
- [x] Updated tests to match actual API response format
- [x] Security test validates no sensitive data in error messages
- [ ] Manual test: Upload image in Simple Flow
- [ ] Manual test: Verify image displays correctly after upload
- [ ] Manual test: Deploy token with uploaded image

## Related Issue
Fixes the IPFS upload error reported by user in Simple template flow.

🤖 Generated with [Claude Code](https://claude.ai/code)